### PR TITLE
fix: remove some generic warnings when building

### DIFF
--- a/src/org/um/feri/ears/algorithms/MOAlgorithm.java
+++ b/src/org/um/feri/ears/algorithms/MOAlgorithm.java
@@ -185,7 +185,7 @@ public abstract class MOAlgorithm<T extends MOTask, Type extends Number> extends
 		long estimatedTime = System.currentTimeMillis() - initTime;
 		//System.out.println("Total execution time: "+estimatedTime + "ms");
 
-		Ranking ranking = new Ranking(best);
+		Ranking<Type> ranking = new Ranking<>(best);
 		best = ranking.getSubfront(0);
 		
 		if(save_data)

--- a/src/org/um/feri/ears/algorithms/moo/dbea/DBEA.java
+++ b/src/org/um/feri/ears/algorithms/moo/dbea/DBEA.java
@@ -118,8 +118,8 @@ public class DBEA<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 	 */
 	private final int divisionsInner;
 	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 	
 	
 	public DBEA(CrossoverOperator crossover, MutationOperator mutation, MOTask problem) {

--- a/src/org/um/feri/ears/algorithms/moo/demo/DEMO.java
+++ b/src/org/um/feri/ears/algorithms/moo/demo/DEMO.java
@@ -63,7 +63,7 @@ public class DEMO<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 
     MOSolutionBase<Type> parents[] ;
     
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
     
 
 	public DEMO(CrossoverOperator crossover, int populationSize, int selectionProcedure) {

--- a/src/org/um/feri/ears/algorithms/moo/gde3/GDE3.java
+++ b/src/org/um/feri/ears/algorithms/moo/gde3/GDE3.java
@@ -21,25 +21,22 @@
 
 package org.um.feri.ears.algorithms.moo.gde3;
 
-import java.util.Comparator;
-
 import org.um.feri.ears.algorithms.AlgorithmInfo;
 import org.um.feri.ears.algorithms.Author;
 import org.um.feri.ears.algorithms.EnumAlgorithmParameters;
 import org.um.feri.ears.algorithms.MOAlgorithm;
 import org.um.feri.ears.operators.CrossoverOperator;
-import org.um.feri.ears.operators.DifferentialEvolutionCrossover;
 import org.um.feri.ears.operators.DifferentialEvolutionSelection;
 import org.um.feri.ears.problems.MOTask;
 import org.um.feri.ears.problems.StopCriteriaException;
 import org.um.feri.ears.problems.moo.MOSolutionBase;
 import org.um.feri.ears.problems.moo.ParetoSolution;
-import org.um.feri.ears.util.Cache;
 import org.um.feri.ears.util.CrowdingComparator;
 import org.um.feri.ears.util.Distance;
 import org.um.feri.ears.util.DominanceComparator;
 import org.um.feri.ears.util.Ranking;
-import org.um.feri.ears.util.Util;
+
+import java.util.Comparator;
 
 /**
  * This class implements the GDE3 algorithm. 
@@ -52,9 +49,9 @@ public class GDE3<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 	
 	int populationSize;
 	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
 
-	public GDE3(CrossoverOperator crossover, int populationSize) {
+	public GDE3(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, int populationSize) {
 		this.populationSize = populationSize;
 		this.cross = crossover;
 
@@ -88,8 +85,8 @@ public class GDE3<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 		Distance<Type> distance;
 		Comparator<MOSolutionBase<Type>> dominance;
 
-		distance = new Distance();
-		dominance = new DominanceComparator();
+		distance = new Distance<>();
+		dominance = new DominanceComparator<>();
 
 		MOSolutionBase<Type> parent[] = null;
 
@@ -177,7 +174,7 @@ public class GDE3<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 			if (remain > 0) { // front contains individuals to insert
 				while (front.size() > remain) {
 					distance.crowdingDistanceAssignment(front, num_obj);
-					front.remove(front.indexWorst(new CrowdingComparator()));
+					front.remove(front.indexWorst(new CrowdingComparator<>()));
 				}
 				for (int k = 0; k < front.size(); k++) {
 					population.add(front.get(k));
@@ -188,7 +185,7 @@ public class GDE3<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 		}
 		
 		// Return the first non-dominated front
-		Ranking ranking = new Ranking(population);
+		Ranking<Type> ranking = new Ranking<>(population);
 		best = ranking.getSubfront(0);
 	}
 }

--- a/src/org/um/feri/ears/algorithms/moo/gde3/I_GDE3.java
+++ b/src/org/um/feri/ears/algorithms/moo/gde3/I_GDE3.java
@@ -3,6 +3,7 @@ package org.um.feri.ears.algorithms.moo.gde3;
 import org.um.feri.ears.operators.CrossoverOperator;
 import org.um.feri.ears.operators.PMXCrossover;
 import org.um.feri.ears.problems.IntegerMOTask;
+import org.um.feri.ears.problems.moo.MOSolutionBase;
 
 public class I_GDE3 extends GDE3<IntegerMOTask, Integer> {
 	
@@ -14,7 +15,7 @@ public class I_GDE3 extends GDE3<IntegerMOTask, Integer> {
 		this(new PMXCrossover(), populationSize);
 	}
 
-	public I_GDE3(CrossoverOperator crossover, int populationSize) {
+	public I_GDE3(CrossoverOperator<Integer, IntegerMOTask, MOSolutionBase<Integer>> crossover, int populationSize) {
 		super(crossover, populationSize);
 	}
 	

--- a/src/org/um/feri/ears/algorithms/moo/ibea/D_IBEA.java
+++ b/src/org/um/feri/ears/algorithms/moo/ibea/D_IBEA.java
@@ -1,12 +1,12 @@
 package org.um.feri.ears.algorithms.moo.ibea;
 
-import org.um.feri.ears.algorithms.moo.nsga2.NSGAII;
 import org.um.feri.ears.operators.CrossoverOperator;
 import org.um.feri.ears.operators.MutationOperator;
 import org.um.feri.ears.operators.PolynomialMutation;
 import org.um.feri.ears.operators.SBXCrossover;
 import org.um.feri.ears.problems.DoubleMOTask;
 import org.um.feri.ears.problems.StopCriteriaException;
+import org.um.feri.ears.problems.moo.MOSolutionBase;
 
 public class D_IBEA extends IBEA<DoubleMOTask, Double> {
 	
@@ -22,7 +22,7 @@ public class D_IBEA extends IBEA<DoubleMOTask, Double> {
 		this(new SBXCrossover(0.9, 20.0), new PolynomialMutation(1.0 / 10, 20.0), populationSize, archiveSize);
 	}
 
-	public D_IBEA(CrossoverOperator crossover, MutationOperator mutation, int populationSize, int archiveSize) {
+	public D_IBEA(CrossoverOperator<Double, DoubleMOTask, MOSolutionBase<Double>> crossover, MutationOperator<Double, DoubleMOTask, MOSolutionBase<Double>> mutation, int populationSize, int archiveSize) {
 		super(crossover, mutation, populationSize, archiveSize);
 	}
 

--- a/src/org/um/feri/ears/algorithms/moo/ibea/IBEA.java
+++ b/src/org/um/feri/ears/algorithms/moo/ibea/IBEA.java
@@ -49,8 +49,8 @@ public class IBEA<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 	ParetoSolution<Type> population;
 	ParetoSolution<Type> archive;
 	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 	
 	/**
 	 * Defines the number of tournaments for creating the mating pool
@@ -68,11 +68,11 @@ public class IBEA<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 	 */
 	private double maxIndicatorValue_;
 
-	public IBEA(CrossoverOperator crossover, MutationOperator mutation, int populationSize, int archiveSize) {
+	public IBEA(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int populationSize, int archiveSize) {
 		this(crossover, mutation, populationSize, archiveSize, "IBEA");
 	}
 
-	public IBEA(CrossoverOperator crossover, MutationOperator mutation, int populationSize, int archiveSize, String name) {
+	public IBEA(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int populationSize, int archiveSize, String name) {
 		
 		this.cross = crossover;
 		this.mut = mutation;
@@ -109,7 +109,7 @@ public class IBEA<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 		}
 
 		while (!task.isStopCriteria()) {
-	      ParetoSolution<Type> union = ((ParetoSolution<Type>)population).union(archive);
+	      ParetoSolution<Type> union = population.union(archive);
 	      calculateFitness(union);
 	      archive = union;
 	      
@@ -265,7 +265,7 @@ public class IBEA<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 				B = new ParetoSolution<Type>(1);
 				B.add(solutionSet.get(i));
 
-				int flag = (new DominanceComparator()).compare(A.get(0), B.get(0));
+				int flag = (new DominanceComparator<Type>()).compare(A.get(0), B.get(0));
 
 				double value = 0.0;
 				if (flag == -1) {

--- a/src/org/um/feri/ears/algorithms/moo/moead/D_MOEAD.java
+++ b/src/org/um/feri/ears/algorithms/moo/moead/D_MOEAD.java
@@ -1,13 +1,12 @@
 package org.um.feri.ears.algorithms.moo.moead;
 
-import org.um.feri.ears.algorithms.moo.nsga2.NSGAII;
 import org.um.feri.ears.operators.CrossoverOperator;
 import org.um.feri.ears.operators.DifferentialEvolutionCrossover;
 import org.um.feri.ears.operators.MutationOperator;
 import org.um.feri.ears.operators.PolynomialMutation;
-import org.um.feri.ears.operators.SBXCrossover;
 import org.um.feri.ears.problems.DoubleMOTask;
 import org.um.feri.ears.problems.StopCriteriaException;
+import org.um.feri.ears.problems.moo.MOSolutionBase;
 
 public class D_MOEAD extends MOEAD<DoubleMOTask, Double> {
 	
@@ -19,7 +18,7 @@ public class D_MOEAD extends MOEAD<DoubleMOTask, Double> {
 		this(new DifferentialEvolutionCrossover(), new PolynomialMutation(1.0 / 10, 20.0), populationSize);
 	}
 
-	public D_MOEAD(CrossoverOperator crossover, MutationOperator mutation, int populationSize) {
+	public D_MOEAD(CrossoverOperator<Double, DoubleMOTask, MOSolutionBase<Double>> crossover, MutationOperator<Double, DoubleMOTask, MOSolutionBase<Double>> mutation, int populationSize) {
 		super(crossover, mutation, populationSize);
 	}
 

--- a/src/org/um/feri/ears/algorithms/moo/moead/MOEAD.java
+++ b/src/org/um/feri/ears/algorithms/moo/moead/MOEAD.java
@@ -51,7 +51,7 @@ import org.um.feri.ears.util.Util;
  * </ol>
  */
 public class MOEAD<T extends MOTask, Type extends Number> extends MOAlgorithm<T, Type> {
-	
+
 	List<Integer> twoDimfiles = asList(100, 300, 400, 500, 600, 800, 1000);
 	List<Integer> threeDimfiles = asList(500, 600, 800, 1000, 1200);
 	List<Integer> fiveDimfiles = asList(1000, 1200, 1500, 1800, 2000, 2500);
@@ -94,17 +94,17 @@ public class MOEAD<T extends MOTask, Type extends Number> extends MOAlgorithm<T,
 	MOSolutionBase<Type>[] indArray;
 	String functionType;
 	int gen;
-	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 
 	static String dataDirectory = "Weight";
 
-	public MOEAD(CrossoverOperator crossover, MutationOperator mutation, int pop_size) {
+	public MOEAD(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int pop_size) {
 		this(crossover, mutation, pop_size, "MOEAD");
 	}
-	
-	public MOEAD(CrossoverOperator crossover, MutationOperator mutation, int pop_size, String name) {
+
+	public MOEAD(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int pop_size, String name) {
 		this.populationSize = pop_size;
 		this.cross = crossover;
 		this.mut = mutation;
@@ -121,7 +121,7 @@ public class MOEAD<T extends MOTask, Type extends Number> extends MOAlgorithm<T,
 
 	@Override
 	protected void init() throws StopCriteriaException {
-		
+
 		if(optimalParam)
 		{
 			switch(num_obj){
@@ -147,7 +147,7 @@ public class MOEAD<T extends MOTask, Type extends Number> extends MOAlgorithm<T,
 			}
 			}
 		}
-		
+
 		ai.addParameter(EnumAlgorithmParameters.POP_SIZE, populationSize+"");
 
 		population = new ParetoSolution<Type>(populationSize);
@@ -179,7 +179,7 @@ public class MOEAD<T extends MOTask, Type extends Number> extends MOAlgorithm<T,
 
 	@Override
 	protected void start() throws StopCriteriaException {
-		
+
 		// STEP 2. Update
 		do {
 			int[] permutation = Util.randomPermutation(populationSize);
@@ -235,12 +235,12 @@ public class MOEAD<T extends MOTask, Type extends Number> extends MOAlgorithm<T,
 			task.incrementNumberOfIterations();
 		} while (!task.isStopCriteria());
 		//System.out.println(gen);
-		Ranking ranking = new Ranking(population);
+		Ranking<Type> ranking = new Ranking<>(population);
 		best = ranking.getSubfront(0);
 	}
 
 	public void initUniformWeight() {
-		
+
 		lambda = InitWeight.generate(num_obj, populationSize, true);
 		/*
 		if ((num_obj == 2) && (populationSize <= 100)) {
@@ -443,7 +443,7 @@ public class MOEAD<T extends MOTask, Type extends Number> extends MOAlgorithm<T,
 				maxFun = feval;
 			}
 		}
-		
+
 		fitness = maxFun;
 		/*if (individual.violatesConstraints()) {
 			fitness += 10000.0;

--- a/src/org/um/feri/ears/algorithms/moo/moead_dra/MOEAD_DRA.java
+++ b/src/org/um/feri/ears/algorithms/moo/moead_dra/MOEAD_DRA.java
@@ -86,10 +86,10 @@ public class MOEAD_DRA<T extends MOTask, Type extends Number> extends MOAlgorith
 
 	static String dataDirectory = "Weight";
 
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 
-	public MOEAD_DRA(CrossoverOperator crossover, MutationOperator mutation, int pop_size) {
+	public MOEAD_DRA(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int pop_size) {
 		this.populationSize = pop_size;
 
 		this.cross = crossover;

--- a/src/org/um/feri/ears/algorithms/moo/moead_dra/MOEAD_STM.java
+++ b/src/org/um/feri/ears/algorithms/moo/moead_dra/MOEAD_STM.java
@@ -38,7 +38,7 @@ public class MOEAD_STM<T extends MOTask, Type extends Number> extends MOEAD_DRA<
 	ParetoSolution<Type> jointPopulation;
 	
 	
-	public MOEAD_STM(CrossoverOperator crossover, MutationOperator mutation, int pop_size) {
+	public MOEAD_STM(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int pop_size) {
 		super(crossover, mutation, pop_size);
 
 		au = new Author("miha", "miha.ravber at gamil.com");

--- a/src/org/um/feri/ears/algorithms/moo/nsga2/NSGAII.java
+++ b/src/org/um/feri/ears/algorithms/moo/nsga2/NSGAII.java
@@ -47,14 +47,14 @@ public class NSGAII<T extends MOTask, Type extends Number> extends MOAlgorithm<T
 	ParetoSolution<Type> union;
 
 	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 
-	public NSGAII(CrossoverOperator crossover, MutationOperator mutation, int populationSize) {
+	public NSGAII(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int populationSize) {
 		this(crossover, mutation, populationSize, "NSGAII");
 	}
 	
-	public NSGAII(CrossoverOperator crossover, MutationOperator mutation, int populationSize, String name) {
+	public NSGAII(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int populationSize, String name) {
 
 		this.cross = crossover;
 		this.mut = mutation;
@@ -150,7 +150,7 @@ public class NSGAII<T extends MOTask, Type extends Number> extends MOAlgorithm<T
 			// Remain is less than front(index).size, insert only the best one
 			if (remain > 0) { // front contains individuals to insert
 				distance.crowdingDistanceAssignment(front, num_obj);
-				front.sort(new CrowdingComparator());
+				front.sort(new CrowdingComparator<>());
 				for (int k = 0; k < remain; k++) {
 					population.add(front.get(k));
 				}

--- a/src/org/um/feri/ears/algorithms/moo/nsga3/NSGAIII.java
+++ b/src/org/um/feri/ears/algorithms/moo/nsga3/NSGAIII.java
@@ -64,8 +64,8 @@ public class NSGAIII<T extends MOTask, Type extends Number> extends MOAlgorithm<
 	SBXCrossover sbx ;
 	PolynomialMutation plm;
 	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 
 
 	public NSGAIII(CrossoverOperator crossover, MutationOperator mutation) {

--- a/src/org/um/feri/ears/algorithms/moo/paes/PAES.java
+++ b/src/org/um/feri/ears/algorithms/moo/paes/PAES.java
@@ -30,7 +30,7 @@ public class PAES<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 	int archiveSize = 100;
 	int bisections = 5;
 	
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 
 	public PAES(MutationOperator mutation, int populationSize) {
 		

--- a/src/org/um/feri/ears/algorithms/moo/pesa2/AdaptiveGridArchive.java
+++ b/src/org/um/feri/ears/algorithms/moo/pesa2/AdaptiveGridArchive.java
@@ -25,8 +25,8 @@ public class AdaptiveGridArchive<Type extends Number> extends ParetoSolution<Typ
 	public AdaptiveGridArchive(int maxSize, int bisections, int objectives) {
 		super(maxSize);
 		this.maxSize = maxSize;
-		dominance = new DominanceComparator();
-		grid = new AdaptiveGrid<Type>(bisections, objectives);
+		dominance = new DominanceComparator<>();
+		grid = new AdaptiveGrid<>(bisections, objectives);
 	}
 
 	/**

--- a/src/org/um/feri/ears/algorithms/moo/pesa2/D_PESAII.java
+++ b/src/org/um/feri/ears/algorithms/moo/pesa2/D_PESAII.java
@@ -7,6 +7,7 @@ import org.um.feri.ears.operators.PolynomialMutation;
 import org.um.feri.ears.operators.SBXCrossover;
 import org.um.feri.ears.problems.DoubleMOTask;
 import org.um.feri.ears.problems.StopCriteriaException;
+import org.um.feri.ears.problems.moo.MOSolutionBase;
 
 public class D_PESAII extends PESAII<DoubleMOTask, Double> {
 	
@@ -22,7 +23,7 @@ public class D_PESAII extends PESAII<DoubleMOTask, Double> {
 		this(new SBXCrossover(0.9, 20.0), new PolynomialMutation(1.0 / 10, 20.0), populationSize, archiveSize);
 	}
 
-	public D_PESAII(CrossoverOperator crossover, MutationOperator mutation, int populationSize, int archiveSize) {
+	public D_PESAII(CrossoverOperator<Double, DoubleMOTask, MOSolutionBase<Double>> crossover, MutationOperator<Double, DoubleMOTask, MOSolutionBase<Double>> mutation, int populationSize, int archiveSize) {
 		super(crossover, mutation, populationSize, archiveSize);
 	}
 

--- a/src/org/um/feri/ears/algorithms/moo/pesa2/PESAII.java
+++ b/src/org/um/feri/ears/algorithms/moo/pesa2/PESAII.java
@@ -14,14 +14,10 @@ import org.um.feri.ears.algorithms.MOAlgorithm;
 import org.um.feri.ears.operators.CrossoverOperator;
 import org.um.feri.ears.operators.MutationOperator;
 import org.um.feri.ears.operators.PESA2Selection;
-import org.um.feri.ears.operators.PolynomialMutation;
-import org.um.feri.ears.operators.SBXCrossover;
 import org.um.feri.ears.problems.MOTask;
 import org.um.feri.ears.problems.StopCriteriaException;
 import org.um.feri.ears.problems.moo.MOSolutionBase;
 import org.um.feri.ears.problems.moo.ParetoSolution;
-import org.um.feri.ears.util.Cache;
-import org.um.feri.ears.util.Util;
 public class PESAII<T extends MOTask, Type extends Number> extends MOAlgorithm<T, Type>{
 
 	int populationSize = 100;
@@ -30,15 +26,15 @@ public class PESAII<T extends MOTask, Type extends Number> extends MOAlgorithm<T
 	ParetoSolution<Type> population;
 	AdaptiveGridArchive<Type> archive;
 	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 	
 
-	public PESAII(CrossoverOperator crossover, MutationOperator mutation, int populationSize, int archiveSize) {
+	public PESAII(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int populationSize, int archiveSize) {
 		this(crossover, mutation, populationSize, archiveSize, "PESAII");
 	}
 	
-	public PESAII(CrossoverOperator crossover, MutationOperator mutation, int populationSize, int archiveSize, String name) {
+	public PESAII(CrossoverOperator<Type, T, MOSolutionBase<Type>> crossover, MutationOperator<Type, T, MOSolutionBase<Type>> mutation, int populationSize, int archiveSize, String name) {
 		this.populationSize = populationSize;
 		this.archiveSize = archiveSize;
 		

--- a/src/org/um/feri/ears/algorithms/moo/pesa2MOEA/PESA2.java
+++ b/src/org/um/feri/ears/algorithms/moo/pesa2MOEA/PESA2.java
@@ -70,8 +70,8 @@ public class PESA2<T extends MOTask, Type extends Number> extends MOAlgorithm<T,
 	 */
 	protected Map<Integer, List<MOSolutionBase<Type>>> gridMap;
 	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 
 	public PESA2(CrossoverOperator crossover, MutationOperator mutation, int populationSize) {
 		this.populationSize = populationSize;

--- a/src/org/um/feri/ears/algorithms/moo/spea2/SPEA2.java
+++ b/src/org/um/feri/ears/algorithms/moo/spea2/SPEA2.java
@@ -32,8 +32,8 @@ public class SPEA2<T extends MOTask, Type extends Number> extends MOAlgorithm<T,
 	ParetoSolution<Type> population;
 	ParetoSolution<Type> archive;
 	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 
 	public int tournamentRounds = 1;
 

--- a/src/org/um/feri/ears/algorithms/moo/vega/VEGA.java
+++ b/src/org/um/feri/ears/algorithms/moo/vega/VEGA.java
@@ -59,8 +59,8 @@ public class VEGA<T extends MOTask, Type extends Number> extends MOAlgorithm<T, 
 	int populationSize;
 	ParetoSolution<Type> population;
 	
-	CrossoverOperator<Type, MOTask, MOSolutionBase<Type>> cross;
-	MutationOperator<Type, MOTask, MOSolutionBase<Type>> mut;
+	CrossoverOperator<Type, T, MOSolutionBase<Type>> cross;
+	MutationOperator<Type, T, MOSolutionBase<Type>> mut;
 
 	public VEGA(CrossoverOperator crossover, MutationOperator mutation, int pop_size) {
 		this.populationSize = pop_size;

--- a/src/org/um/feri/ears/benchmark/example/MainBenchMarkTestMOO.java
+++ b/src/org/um/feri/ears/benchmark/example/MainBenchMarkTestMOO.java
@@ -11,6 +11,7 @@ import org.um.feri.ears.algorithms.moo.nsga2.D_NSGAII;
 import org.um.feri.ears.algorithms.moo.spea2.D_SPEA2;
 import org.um.feri.ears.benchmark.RatingBenchmark;
 import org.um.feri.ears.benchmark.RatingCEC2009;
+import org.um.feri.ears.problems.DoubleMOTask;
 import org.um.feri.ears.problems.results.BankOfResults;
 import org.um.feri.ears.qualityIndicator.QualityIndicator.IndicatorName;
 import org.um.feri.ears.rating.Player;
@@ -23,7 +24,7 @@ public class MainBenchMarkTestMOO {
 		
         Util.rnd.setSeed(System.currentTimeMillis());
         RatingBenchmark.debugPrint = true; //prints one on one results
-        ArrayList<MOAlgorithm> players = new ArrayList<MOAlgorithm>();
+        ArrayList<MOAlgorithm<DoubleMOTask,Double>> players = new ArrayList<>();
         players.add(new D_MOEAD_DRA());
         players.add(new D_NSGAII());
         players.add(new D_SPEA2());
@@ -36,7 +37,7 @@ public class MainBenchMarkTestMOO {
         indicators.add(IndicatorName.IGD); // add quality indicator
         
         RatingCEC2009 cec = new RatingCEC2009(indicators, 0.0000001); //Create banchmark
-        for (MOAlgorithm al:players) {
+        for (MOAlgorithm<DoubleMOTask, Double> al:players) {
         	ra.addPlayer(al, al.getID(), 1500, 350, 0.06,0,0,0); //init rating 1500
         	cec.registerAlgorithm(al);
         }

--- a/src/org/um/feri/ears/problems/moo/MOSolutionBase.java
+++ b/src/org/um/feri/ears/problems/moo/MOSolutionBase.java
@@ -81,7 +81,7 @@ public class MOSolutionBase<Type> extends SolutionBase<Type> {
 	}
 
 	public MOSolutionBase<Type> copy() {
-		return new MOSolutionBase(this);
+		return new MOSolutionBase<>(this);
 	}
 	
 	/**

--- a/src/org/um/feri/ears/problems/moo/ParetoSolution.java
+++ b/src/org/um/feri/ears/problems/moo/ParetoSolution.java
@@ -50,7 +50,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		}
 		overallConstraintViolation_  = ps.getOverallConstraintViolation();
 		numberOfViolatedConstraints_ = ps.getNumberOfViolatedConstraint();
-		
+
 		solutions = new ArrayList<MOSolutionBase<Type>>();
 		for (MOSolutionBase<Type> sol : ps) {
 			solutions.add(sol.copy());
@@ -59,9 +59,9 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 
 	public List<MOSolutionBase<Type>> solutions;
 	private double pareto_eval;
-	
+
 	private HashMap<String,Double> qiEval = new HashMap<String,Double>();
-	
+
 	/**
 	 * Returns evaluations for all unary quality indicators.
 	 * @return all unary quality indicators evaluations.
@@ -69,7 +69,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 	public HashMap<String, Double> getAllQiEval() {
 		return qiEval;
 	}
-	
+
 	public void setEvalForAllUnaryQIs(HashMap<String, Double> qiEval) {
 		this.qiEval = qiEval;
 	}
@@ -78,7 +78,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 	 * Maximum size of the solution set
 	 */
 	private int capacity = 0;
-	
+
 	public ParetoSolution() {
 		solutions = new ArrayList<MOSolutionBase<Type>>();
 		capacity = 1000;
@@ -115,20 +115,20 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		solutions.add(solution);
 		return true;
 	}
-	
+
 	/**
 	 * Replaces the solution at the given index.
-	 * 
+	 *
 	 * @param index the index to replace
 	 * @param solution the new solution
 	 */
 	public void replace(int index, MOSolutionBase<Type> solution) {
 		solutions.set(index, solution);
 	}
-	
+
 	/**
 	 * Adds a collection of solutions to this population.
-	 * 
+	 *
 	 * @param iterable the collection of solutions to be added
 	 * @return {@code true} if the population was modified as a result of this
 	 *         method; {@code false} otherwise
@@ -142,9 +142,9 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 
 		return changed;
 	}
-	
+
 	public void addAll(List<MOSolutionBase<Type>> pop) {
-		
+
 		for (MOSolutionBase<Type> solution : pop) {
 			add(solution);
 		}
@@ -156,16 +156,16 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		}
 		return solutions.get(i);
 	}
-	
+
 	public void set(int index, MOSolutionBase<Type> solution)
 	{
 		solutions.set(index, solution);
 	}
-	
+
 	/**
 	 * Returns {@code true} if this population contains no solutions;
 	 * {@code false} otherwise.
-	 * 
+	 *
 	 * @return {@code true} if this population contains no solutions;
 	 *         {@code false} otherwise.
 	 */
@@ -185,12 +185,12 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 
 		return pareto_eval;
 	}
-	
-	public void evaluate(QualityIndicator qi) throws Exception
+
+	public void evaluate(QualityIndicator<Type> qi) throws Exception
 	{
 		this.evaluate(qi,false);
 	}
-	
+
 	/**
 	 * Evaluates the Pareto approximation with the given quality indicator. If {@code usecache} is set to true
 	 * and the Pareto approximation is already evaluated with the given {@code qi}, that value is used.
@@ -198,7 +198,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 	 * @param usecache set to true to read from cache
 	 * @throws Exception if {@code qi} is null or an incorrect type
 	 */
-    public void evaluate(QualityIndicator qi, boolean usecache) throws Exception
+    public void evaluate(QualityIndicator<Type> qi, boolean usecache) throws Exception
     {
     	if(usecache)
     	{
@@ -208,15 +208,15 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
     			return;
     		}
     	}
-    	
+
     	// throw error if the indicator is null or not unary
     	if(qi == null || qi.getIndicatorType() != IndicatorType.Unary)
 			throw new Exception("Indicator is null or incorrect indicator type!");
 		pareto_eval = qi.evaluate(this);
-		
+
 		qiEval.put(qi.getName(), pareto_eval); //replace value
     }
-    
+
     public void evaluteWithAllUnaryQI(int num_obj, String file_name) throws Exception
     {
     	for (IndicatorName name : IndicatorName.values()) {
@@ -228,21 +228,21 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
     	}
     }
 
-	
-	public boolean isFirstBetter(ParetoSolution second, QualityIndicator qi) 
+
+	public boolean isFirstBetter(ParetoSolution<Type> second, QualityIndicator<Type> qi)
 	{
 		if(qi == null)
 		{
 			System.err.println("Indicator is null!");
 			return false;
 		}
-		
+
 		if(qi.getIndicatorType() == QualityIndicator.IndicatorType.Unary)
 		{
 		    if (qi.isMin())
 				return this.getEval() < second.getEval();
 			return this.getEval() > second.getEval();
-		    
+
 		}
 		else if(qi.getIndicatorType() == QualityIndicator.IndicatorType.Binary)
 		{
@@ -255,7 +255,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		}
 		return false;
 	}
-	
+
 	@Override
 	public List<Type> getVariables() {
 		List<Type> x = null; //TODO check
@@ -274,10 +274,10 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 	public int size() {
 		return solutions.size();
 	}
-	
+
 	/**
 	 * Removes the solution at the specified index from this population.
-	 * 
+	 *
 	 * @param index the index of the solution to be removed
 	 * @throws IndexOutOfBoundsException if the index is out of range
 	 *         {@code (index < 0) || (index >= size())}
@@ -286,10 +286,10 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		modCount++;
 		solutions.remove(index);
 	}
-	
+
 	/**
 	 * Removes the specified solution from this population, if present.
-	 * 
+	 *
 	 * @param solution the solution to be removed
 	 * @return {@code true} if this population was modified as a result of this
 	 *         method; {@code false} otherwise
@@ -298,11 +298,11 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		modCount++;
 		return solutions.remove(solution);
 	}
-	
+
 	/**
 	 * Returns {@code true} if this population contains the specified solution;
 	 * {@code false} otherwise.
-	 * 
+	 *
 	 * @param solution the solution whose presence is tested
 	 * @return {@code true} if this population contains the specified
 	 *         solution; {@code false} otherwise
@@ -310,7 +310,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 	public boolean contains(MOSolutionBase<Type> solution) {
 		return solutions.contains(solution);
 	}
-	
+
 	public void displayAllUnaryQulaityIndicators(int num_obj, String file_name)
 	{
 		 ArrayList<QualityIndicator<Type>> indicators = new ArrayList<QualityIndicator<Type>>();
@@ -321,19 +321,19 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 			  if(qi.getIndicatorType() == IndicatorType.Unary)
 				  indicators.add(qi);
 		 }
-		 
+
 		 System.out.println("Quality indicators\n");
 		 for (QualityIndicator<Type> qi : indicators) {
 			value = qi.evaluate(this);
 			System.out.println(qi.getName()+": " + value);
 		}
 	}
-	
-	 /** 
+
+	 /**
 	  * Returns the index of the worst Solution using a <code>Comparator</code>.
 	  * If there are more than one occurrences, only the index of the first one is returned
 	  * @param comparator <code>Comparator</code> used to compare solutions.
-	  * @return The index of the worst Solution attending to the comparator or 
+	  * @return The index of the worst Solution attending to the comparator or
 	  * <code>-1<code> if the SolutionSet is empty
 	  */
 	public int indexWorst(Comparator<MOSolutionBase<Type>> comparator) {
@@ -356,23 +356,23 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 
 		return index;
 	}
-	
-	/** 
+
+	/**
 	 * Returns a new <code>MOParetoIndividual</code> which is the result of the union
 	 * between the current solution set and the one passed as a parameter.
 	 * @param ParetoSolution MOParetoIndividual to join with the current MOParetoIndividual.
 	 * @return The result of the union operation.
 	 */
-	public ParetoSolution union(ParetoSolution solutionSet) {
+	public ParetoSolution<Type> union(ParetoSolution<Type> solutionSet) {
 		// Check the correct size. In development
 		int newSize = this.size() + solutionSet.size();
 		if (newSize < capacity)
 			newSize = capacity;
 
 		// Create a new population
-		ParetoSolution union = new ParetoSolution(newSize);
+		ParetoSolution<Type> union = new ParetoSolution<>(newSize);
 		for (int i = 0; i < this.size(); i++) {
-			union.add(this.get(i));
+			union.add(get(i));
 		}
 
 		for (int i = this.size(); i < (this.size() + solutionSet.size()); i++) {
@@ -388,7 +388,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 
 		Collections.sort(solutions, comparator);
 	}
-	
+
 	/**
    * Copies the objectives of the solution set to a matrix
    * @return A matrix containing the objectives
@@ -406,7 +406,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		}
 		return objectives;
 	}
-	
+
 	public void loadObjectivesFromFile(String fileName)
 	{
 		try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(fileName)))){
@@ -431,7 +431,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 			e.printStackTrace();
 		}
 	}
-	
+
     /**
      * Prints the objectives to a file in CSV format.
      * @param file_name The name of the file.
@@ -448,7 +448,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 			e.printStackTrace();
 		}
 	}
-	
+
 	 /**
      * Prints the variables to a file.
      * @param file_name The name of the file.
@@ -497,7 +497,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 
 		final String algorithm_name = algorithm.replace("_", "\\_");
 		final String problem_name = problemN.replace("_", "\\_");
-		
+
 		final double[][] front = this.writeObjectivesToMatrix();
 		Thread t = new Thread(new Runnable() {
 			public void run() {
@@ -528,7 +528,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 	}
 
 	public void saveParetoImage(final String algorithm_name,final String problem_name) {
-		
+
 		final double[][] front = this.writeObjectivesToMatrix();
 		Thread t = new Thread(new Runnable() {
 	         public void run()
@@ -557,7 +557,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		});
 		t.start();
 	}
-	
+
 	/**
 	 * Returns an iterator for accessing the solutions in this population.
 	 */
@@ -565,13 +565,13 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 	public Iterator<MOSolutionBase<Type>> iterator() {
 		return new PopulationIterator();
 	}
-	
+
 	/*
 	 * The following code is based on the Apache Commons Collections library.
 	 * This is to provide a similar iterator behavior to other collection
 	 * classes without requiring the Population to implement all collection
 	 * methods.  The license terms are provided below.
-	 * 
+	 *
 	 * Licensed to the Apache Software Foundation (ASF) under one or more
 	 * contributor license agreements.  See the NOTICE file distributed with
 	 * this work for additional information regarding copyright ownership.
@@ -587,7 +587,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 	 * See the License for the specific language governing permissions and
 	 * limitations under the License.
 	 */
-	
+
 	/**
 	 * The modification count.
 	 */
@@ -617,13 +617,13 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
          * the operations.
          */
 		private int expectedModCount;
-		
+
 		/**
 		 * Constructs a population iterator.
 		 */
 		public PopulationIterator() {
 			super();
-			
+
 			nextIndex = 0;
 			currentIndex = -1;
 			expectedModCount = modCount;
@@ -637,11 +637,11 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		@Override
 		public MOSolutionBase<Type> next() {
 			checkModCount();
-			
+
 			if (!hasNext()) {
 				throw new NoSuchElementException();
 			}
-			
+
 			try {
 				MOSolutionBase<Type> value = get(nextIndex);
 				currentIndex = nextIndex++;
@@ -654,7 +654,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		@Override
 		public void remove() {
 			checkModCount();
-			
+
 			if (currentIndex == -1) {
 				throw new IllegalStateException();
 			}
@@ -672,7 +672,7 @@ public class ParetoSolution<Type extends Number> extends SolutionBase<Type> impl
 		/**
          * Checks the modification count of the list is the value that this
          * object expects.
-         * 
+         *
          * @throws ConcurrentModificationException if the list's modification
          *         count is not the value that was expected
          */

--- a/src/org/um/feri/ears/problems/results/BankOfResults.java
+++ b/src/org/um/feri/ears/problems/results/BankOfResults.java
@@ -43,7 +43,7 @@ public class BankOfResults {
 		Vector<String> algorithms = new Vector<String>();
 		Vector<String> datasets = new Vector<String>();
 		StringBuffer sb = new StringBuffer();
-		ArrayList<Algorithm> tmp = new ArrayList(all.keySet());
+		ArrayList<AlgorithmBase> tmp = new ArrayList<>(all.keySet());
 		ArrayList<TaskBase> tmpProblem; // = new ArrayList(all.keySet());
 		Hashtable<TaskBase,ArrayList<Double>> tmpA;
 		ArrayList<Double> tmpB;
@@ -53,11 +53,11 @@ public class BankOfResults {
 
 		int i=-1;
 		int j=-1;
-		for (Algorithm  a: tmp) {
+		for (AlgorithmBase a: tmp) {
 			i++;//
 			algorithms.add(a.getID());
 			tmpA =all.get(a);
-			tmpProblem = new ArrayList(tmpA.keySet());
+			tmpProblem = new ArrayList<>(tmpA.keySet());
 			//mean[i] = new double[tmpProblem.size()];
 			j=-1;
 			for (TaskBase  p: tmpProblem) {
@@ -87,14 +87,14 @@ public class BankOfResults {
 	
 	public String toString() {
 		StringBuffer sb = new StringBuffer();
-		ArrayList<Algorithm> tmp = new ArrayList(all.keySet());
+		ArrayList<AlgorithmBase> tmp = new ArrayList<>(all.keySet());
 		ArrayList<TaskBase> tmpProblem; // = new ArrayList(all.keySet());
 		Hashtable<TaskBase,ArrayList<Double>> tmpA;
 		ArrayList<Double> tmpB;
 		DoubleSolution tmpC;
-		for (Algorithm  a: tmp) {
+		for (AlgorithmBase  a: tmp) {
 			tmpA =all.get(a);
-			tmpProblem = new ArrayList(tmpA.keySet());
+			tmpProblem = new ArrayList<>(tmpA.keySet());
 			for (TaskBase  p: tmpProblem) {
 				tmpB = tmpA.get(p);
 				for (Double in:tmpB) {

--- a/src/org/um/feri/ears/qualityIndicator/CoverageOfTwoSets.java
+++ b/src/org/um/feri/ears/qualityIndicator/CoverageOfTwoSets.java
@@ -34,7 +34,7 @@ public class CoverageOfTwoSets<Type extends Number> extends QualityIndicator<Typ
 	/**
 	 * stores a <code>Comparator</code> for dominance checking
 	 */
-	private static final Comparator<MOSolutionBase> dominance_ = new DominanceComparator();
+	private final Comparator<MOSolutionBase<Type>> dominance_ = new DominanceComparator<>();
 	
 	@Override
 	public double evaluate(ParetoSolution<Type> front) {

--- a/src/org/um/feri/ears/qualityIndicator/InvertedGenerationalDistance.java
+++ b/src/org/um/feri/ears/qualityIndicator/InvertedGenerationalDistance.java
@@ -42,7 +42,7 @@ public class InvertedGenerationalDistance<T extends Number> extends QualityIndic
 	 * Constructor. Creates a new instance of the generational distance metric.
 	 */
 	public InvertedGenerationalDistance(int num_obj, String file_name) {
-		super(num_obj, file_name, (ParetoSolution<T>) getReferenceSet(file_name));
+		super(num_obj, file_name, getReferenceSet(file_name));
 		name = "Inverted Generational Distance";
 	}
   

--- a/src/org/um/feri/ears/qualityIndicator/MaximumParetoFrontError.java
+++ b/src/org/um/feri/ears/qualityIndicator/MaximumParetoFrontError.java
@@ -20,7 +20,7 @@ public class MaximumParetoFrontError<T extends Number> extends QualityIndicator<
 	static final double pow_ = 2.0; // pow. This is the pow used for the distances
 
 	public MaximumParetoFrontError(int num_obj, String file_name) {
-		super(num_obj, file_name, (ParetoSolution<T>) getReferenceSet(file_name));
+		super(num_obj, file_name, getReferenceSet(file_name));
 		name = "Maximum Pareto Front Error";
 	}
 	

--- a/src/org/um/feri/ears/qualityIndicator/NativeHV.java
+++ b/src/org/um/feri/ears/qualityIndicator/NativeHV.java
@@ -22,7 +22,7 @@ public class NativeHV<T extends Number> extends QualityIndicator<T>{
 
 	private static final double DELTA_ = 0.01;
 	public NativeHV(int num_obj, String file_name) {
-		super(num_obj, file_name, (ParetoSolution<T>) getReferenceSet(file_name));
+		super(num_obj, file_name, getReferenceSet(file_name));
 		name="WFGHypervolume";
 	}
 

--- a/src/org/um/feri/ears/qualityIndicator/OverallNondominatedVectorGenerationRatio.java
+++ b/src/org/um/feri/ears/qualityIndicator/OverallNondominatedVectorGenerationRatio.java
@@ -19,14 +19,14 @@ import org.um.feri.ears.util.DominanceComparator;
 public class OverallNondominatedVectorGenerationRatio<T extends Number> extends QualityIndicator<T> {
 
 	public OverallNondominatedVectorGenerationRatio(int num_obj, String file_name) {
-		super(num_obj, file_name, (ParetoSolution<T>) getReferenceSet(file_name));
+		super(num_obj, file_name, getReferenceSet(file_name));
 		name = "Overall Nondominated Vector Generation Ratio";
 	}
 	
 	/**
 	 * stores a <code>Comparator</code> for dominance checking
 	 */
-	private static final Comparator<MOSolutionBase> dominance_ = new DominanceComparator();
+	private final Comparator<MOSolutionBase<T>> dominance_ = new DominanceComparator<>();
 	
 	@Override
 	public double evaluate(ParetoSolution<T> population) {

--- a/src/org/um/feri/ears/util/CrowdingComparator.java
+++ b/src/org/um/feri/ears/util/CrowdingComparator.java
@@ -34,7 +34,7 @@ public class CrowdingComparator<Type> extends DominanceComparator<Type> {
 	/**
 	 * stores a comparator for check the rank of solutions
 	 */
-	private static final Comparator<MOSolutionBase> comparator = new RankComparator();
+	private final Comparator<MOSolutionBase<Type>> comparator = new RankComparator<>();
 
 	/**
 	 * Compare two solutions.

--- a/src/org/um/feri/ears/util/Distance.java
+++ b/src/org/um/feri/ears/util/Distance.java
@@ -150,7 +150,7 @@ public class Distance<Type extends Number> {
     * @param solutionSet The <code>SolutionSet</code>.
     * @param nObjs Number of objectives.
     */
-	public void crowdingDistanceAssignment(ParetoSolution solutionSet, int nObjs) {
+	public void crowdingDistanceAssignment(ParetoSolution<Type> solutionSet, int nObjs) {
 		int size = solutionSet.size();
 
 		if (size == 0)
@@ -168,7 +168,7 @@ public class Distance<Type extends Number> {
 		}
 
 		// Use a new SolutionSet to evite alter original solutionSet
-		ParetoSolution front = new ParetoSolution(size);
+		ParetoSolution<Type> front = new ParetoSolution<>(size);
 		for (int i = 0; i < size; i++) {
 			front.add(solutionSet.get(i));
 		}
@@ -182,7 +182,7 @@ public class Distance<Type extends Number> {
 
 		for (int i = 0; i < nObjs; i++) {
 			// Sort the population by Obj n
-			front.sort(new ObjectiveComparator(i));
+			front.sort(new ObjectiveComparator<>(i));
 			objetiveMinn = front.get(0).getObjective(i);
 			objetiveMaxn = front.get(front.size() - 1).getObjective(i);
 

--- a/src/org/um/feri/ears/util/DominanceComparator.java
+++ b/src/org/um/feri/ears/util/DominanceComparator.java
@@ -42,7 +42,7 @@ public class DominanceComparator<Type> implements Comparator<MOSolutionBase<Type
 	}
 	
 	public DominanceComparator(double epsilon) {
-		violationConstraintComparator_ = new OverallConstraintViolationComparator();
+		violationConstraintComparator_ = new OverallConstraintViolationComparator<>();
 		this.epsilon = epsilon;
 	}
 	

--- a/src/org/um/feri/ears/util/NonDominatedSolutionList.java
+++ b/src/org/um/feri/ears/util/NonDominatedSolutionList.java
@@ -35,7 +35,7 @@ public class NonDominatedSolutionList<Type extends Number> extends ParetoSolutio
 	/**
 	* Stores a <code>Comparator</code> for dominance checking
 	*/
-	protected Comparator<MOSolutionBase<Type>> dominanceComparator = new DominanceComparator(); 
+	protected Comparator<MOSolutionBase<Type>> dominanceComparator = new DominanceComparator<>();
 
 	/**
 	* Stores a <code>Comparator</code> for checking if two solutions are equal

--- a/src/org/um/feri/ears/util/SolutionUtils.java
+++ b/src/org/um/feri/ears/util/SolutionUtils.java
@@ -14,7 +14,7 @@ public class SolutionUtils {
 	 * @param solution2
 	 * @return The best solution
 	 */
-	public static <T> MOSolutionBase<T> getBestSolution(MOSolutionBase<T> solution1, MOSolutionBase<T> solution2, Comparator comparator) {
+	public static <T> MOSolutionBase<T> getBestSolution(MOSolutionBase<T> solution1, MOSolutionBase<T> solution2, Comparator<MOSolutionBase<T>> comparator) {
 		MOSolutionBase<T> result ;
 		int flag = comparator.compare(solution1, solution2);
 		if (flag == -1) {


### PR DESCRIPTION
Fixed most of generic parameter warnings, except generic arrays and non-generic classes